### PR TITLE
Fixes redirection to existing feeds

### DIFF
--- a/public/convert/index.html
+++ b/public/convert/index.html
@@ -31,7 +31,7 @@
   </style>
 </head>
 <body>
-<h1>Convert an RSS feed to ActivityPub</h1>  
+<h1>Convert an RSS feed to ActivityPub</h1>
 <p><em>by <a href="https://friend.camp/@darius">Darius Kazemi</a>, <a href="https://github.com/dariusk/rss-to-activitypub">source code here</a></em></p>
 <p>Put the full RSS feed URL in here, and pick a username for the account that will track the feed.</p>
 <p>
@@ -64,7 +64,7 @@ fetch(`/api/convert/?feed=${feed}&username=${username}`)
     // a feed exists in the database
     if (myJson.content) {
       // was it a match on feed
-      if (myJson.feed === feed) {
+      if (myJson.feed === decodeURIComponent(feed)) {
         console.log('feed match!');
         out.innerHTML = `<p>This feed already exists! Follow @${myJson.username}@${domain}.</p>`;
         window.location = `/u/${myJson.username}`;
@@ -85,6 +85,6 @@ fetch(`/api/convert/?feed=${feed}&username=${username}`)
     out.innerHTML = `<p>Error: ${error}</p>`;
   });
 }
-</script>  
+</script>
 </body>
 </html>


### PR DESCRIPTION
Hey over here :wave:

When a feed already exists and is returned, the resource location is URL-encoded, and thus the check against the provided location does not pass.
Here is a naive patch to fix this behavior and avoid the page not to be redirected to the existing content.

Bye :bow: