### PR TITLE
Allow "Bot tagging" by other Fediverse services

### DIFF
--- a/routes/api.js
+++ b/routes/api.js
@@ -92,9 +92,8 @@ function createActor(name, domain, pubkey, displayName, imageUrl, description) {
       'https://www.w3.org/ns/activitystreams',
       'https://w3id.org/security/v1'
     ],
-
     'id': `https://${domain}/u/${name}`,
-    'type': 'Person',
+    'type': 'Service',
     'preferredUsername': `${name}`,
     'inbox': `https://${domain}/api/inbox`,
     'followers': `https://${domain}/u/${name}/followers`,


### PR DESCRIPTION
Hey back, it's me again.

This change sets the created activities' actor type to `Service` to allow "bot detection" by other Fediverse clients.
Mastodon (for example) tags as "bot" incoming activities containing this actor type (see [here](https://github.com/tootsuite/mastodon/pull/7391#issue-186230875)), since v2.4.0.

As this bridge (should) only create(s) automatically-generated content, I think its accounts should be tagged as "services" instead of _real_ "human" entities (when such a detection is implemented).

Tell me what you think about this, bye (again) :wave: