### PR TITLE
Fix compatibility with Mastodon 3.2.1, Pleroma and Misskey

### DIFF
--- a/routes/inbox.js
+++ b/routes/inbox.js
@@ -27,7 +27,8 @@ function signAndSend(message, name, domain, req, res, targetDomain) {
     signer.end();
     const signature = signer.sign(privkey);
     const signature_b64 = signature.toString('base64');
-    let header = `keyId="https://${domain}/u/${name}",headers="(request-target) host date digest",signature="${signature_b64}"`;
+    const algorithm = 'rsa-sha256';
+    let header = `keyId="https://${domain}/u/${name}",algorithm="${algorithm}",headers="(request-target) host date digest",signature="${signature_b64}"`;
     console.log('signature:',header);
     console.log('message:',message);
 

--- a/routes/inbox.js
+++ b/routes/inbox.js
@@ -38,7 +38,9 @@ function signAndSend(message, name, domain, req, res, targetDomain) {
         'Host': targetDomain,
         'Date': d.toUTCString(),
         'Signature': header,
-        'Digest': `SHA-256=${digest}`
+        'Digest': `SHA-256=${digest}`,
+        'Content-Type': 'application/activity+json',
+        'Accept': 'application/activity+json'
       },
       method: 'POST',
       json: true,

--- a/updateFeeds.js
+++ b/updateFeeds.js
@@ -191,7 +191,9 @@ function signAndSend(message, name, domain, req, res, targetDomain, inbox) {
         'Host': targetDomain,
         'Date': d.toUTCString(),
         'Signature': header,
-        'Digest': `SHA-256=${digest}`
+        'Digest': `SHA-256=${digest}`,
+        'Content-Type': 'application/activity+json',
+        'Accept': 'application/activity+json'
       },
       method: 'POST',
       json: true,

--- a/updateFeeds.js
+++ b/updateFeeds.js
@@ -182,7 +182,8 @@ function signAndSend(message, name, domain, req, res, targetDomain, inbox) {
     signer.end();
     const signature = signer.sign(privkey);
     const signature_b64 = signature.toString('base64');
-    let header = `keyId="https://${domain}/u/${name}",headers="(request-target) host date digest",signature="${signature_b64}"`;
+    const algorithm = 'rsa-sha256';
+    let header = `keyId="https://${domain}/u/${name}",algorithm="${algorithm}",headers="(request-target) host date digest",signature="${signature_b64}"`;
     //console.log('signature:',header);
     request({
       url: inbox,


### PR DESCRIPTION
Mastodon 3.2.1 requires digest to be present in the HTTP header and signature. Without digest, any messages will be rejected with an error message `Mastodon requires the Digest header to be signed when doing a POST request`, thus leaving the rss-to-activitypub server in an unusable state.

This PR should work with latest version of Mastodon on master branch and the 3.2.1 version, with and without Secure Mode active. (AUTHORIZED_FETCH=true). Note that mastodon.social is neither running 3.2.1 nor the master branch of Mastodon software, but there are many other instances running the latest versions.
